### PR TITLE
Improve README generator and CI workflow

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -3,33 +3,40 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'README.md'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
 jobs:
   update-readme:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.PAT }}
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    # Run the Python script to update the README
-    - name: Run script to update README
-      run: python update_readme.py
-    # Commit and push the changes if there are any
-    - name: Commit and push changes
-      run: |
-        if [[ -n $(git status -s) ]]; then
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        git add README.md
-        git commit -m "Update README with solution counts"
-        git pull --rebase origin main
-        git push
-        else
-        echo "No changes to commit"
-        fi
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT || github.token }}
+          fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run script to update README
+        run: python update_readme.py
+
+      - name: Commit and push changes
+        run: |
+          if [[ -n $(git status -s README.md) ]]; then
+            git config --local user.email "github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git add README.md
+            git commit -m "chore: update README with solution counts"
+            git pull --rebase origin main
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # This is a Collection of all the LeetCode Problems that I have Solved!
 
-
-
 ## 🧑‍💻 Languages & Stats
-| Language      | Solutions |
-| ------------- | ----------|
-| ![Python](https://img.shields.io/badge/-Python-3776AB?style=flat&logo=python&logoColor=white) | 188 |
-| ![Java](https://img.shields.io/badge/-Java-007396?style=flat&logo=java&logoColor=white) | 6 |
-| ![MySQL](https://img.shields.io/badge/MySQL-4479A1?logo=mysql&logoColor=fff) | 6 |
-| ![C](https://img.shields.io/badge/C-00599C?logo=c&logoColor=white) | 0 |
-| **Total!** | 200 |
 
+<!-- STATS:START -->
+| Language | Solutions |
+| --- | --- |
+| ![Python](https://img.shields.io/badge/-Python-3776AB?style=flat&logo=python&logoColor=white) | 295 |
+| ![Java](https://img.shields.io/badge/-Java-007396?style=flat&logo=java&logoColor=white) | 7 |
+| ![MySQL](https://img.shields.io/badge/-MySQL-4479A1?style=flat&logo=mysql&logoColor=white) | 7 |
+| ![Bash](https://img.shields.io/badge/-Bash-4EAA25?style=flat&logo=gnubash&logoColor=white) | 3 |
+| ![C++](https://img.shields.io/badge/-C++-00599C?style=flat&logo=cplusplus&logoColor=white) | 2 |
+| **Total** | **314** |
+<!-- STATS:END -->

--- a/update_readme.py
+++ b/update_readme.py
@@ -1,64 +1,105 @@
 import os
 import sys
 
-# Define the language extensions and their corresponding names and badges
+# Map file extensions to a (display name, shields.io badge) pair.
+# Several extensions can share a display name (e.g. C++ variants).
+def badge(label, color, logo, logo_color="white"):
+    return (f"![{label}](https://img.shields.io/badge/-{label.replace(' ', '%20')}-"
+            f"{color}?style=flat&logo={logo}&logoColor={logo_color})")
+
 LANGUAGES = {
-    '.py': ('Python', '![Python](https://img.shields.io/badge/-Python-3776AB?style=flat&logo=python&logoColor=white)'),
-    '.java': ('Java', '![Java](https://img.shields.io/badge/-Java-007396?style=flat&logo=java&logoColor=white)'),
-    '.sql': ('SQL', '![MySQL](https://img.shields.io/badge/MySQL-4479A1?logo=mysql&logoColor=fff)'),
-    '.c': ('C', '![C](https://img.shields.io/badge/C-00599C?logo=c&logoColor=white)'),
+    ".py":    ("Python",     badge("Python", "3776AB", "python")),
+    ".java":  ("Java",       badge("Java", "007396", "java")),
+    ".sql":   ("SQL",        badge("MySQL", "4479A1", "mysql")),
+    ".cpp":   ("C++",        badge("C++", "00599C", "cplusplus")),
+    ".cc":    ("C++",        badge("C++", "00599C", "cplusplus")),
+    ".cxx":   ("C++",        badge("C++", "00599C", "cplusplus")),
+    ".c":     ("C",          badge("C", "A8B9CC", "c", "black")),
+    ".sh":    ("Bash",       badge("Bash", "4EAA25", "gnubash")),
+    ".js":    ("JavaScript", badge("JavaScript", "F7DF1E", "javascript", "black")),
+    ".ts":    ("TypeScript", badge("TypeScript", "3178C6", "typescript")),
+    ".go":    ("Go",         badge("Go", "00ADD8", "go")),
+    ".rb":    ("Ruby",       badge("Ruby", "CC342D", "ruby")),
+    ".kt":    ("Kotlin",     badge("Kotlin", "7F52FF", "kotlin")),
+    ".rs":    ("Rust",       badge("Rust", "000000", "rust")),
+    ".swift": ("Swift",      badge("Swift", "F05138", "swift")),
+    ".cs":    ("C#",         badge("C%23", "239120", "csharp")),
+    ".scala": ("Scala",      badge("Scala", "DC322F", "scala")),
+    ".php":   ("PHP",        badge("PHP", "777BB4", "php")),
 }
 
-def count_files_by_extension(root_dir):
-    totalCount = 0
-    counts = {LANGUAGES[ext][0]: 0 for ext in LANGUAGES}
-    for subdir, _, files in os.walk(root_dir):
-        for file in files:
-            ext = os.path.splitext(file)[1]
-            if ext in LANGUAGES:
-                counts[LANGUAGES[ext][0]] += 1
-                totalCount += 1
-    return counts, totalCount
+# Files/dirs that are not solutions.
+EXCLUDE_FILES = {"update_readme.py"}
+EXCLUDE_DIRS = {".git", ".github", "node_modules"}
 
-def update_readme(counts, totalCount):
-    with open('README.md', 'r') as file:
-        readme = file.readlines()
+START_MARK = "<!-- STATS:START -->"
+END_MARK = "<!-- STATS:END -->"
 
-    start_line = None
-    end_line = None
-    for i, line in enumerate(readme):
-        if '| Language      | Solutions |' in line:
-            start_line = i + 2  # Start after the header row
-        elif start_line and line.strip() == '':
-            end_line = i
-            break
 
-    new_table = []
-    for ext, (lang_name, badge) in LANGUAGES.items():
-        count = counts[lang_name]
-        new_table.append(f"| {badge} | {count} |\n")
-    new_table.append(f"| **Total!** | {totalCount} |\n")
+def count_solutions(root_dir):
+    counts = {}         # display name -> count
+    badges = {}         # display name -> badge (first seen)
+    total = 0
+    for subdir, dirs, files in os.walk(root_dir):
+        dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
+        for fname in files:
+            if fname in EXCLUDE_FILES:
+                continue
+            ext = os.path.splitext(fname)[1].lower()
+            if ext not in LANGUAGES:
+                continue
+            name, bdg = LANGUAGES[ext]
+            counts[name] = counts.get(name, 0) + 1
+            badges.setdefault(name, bdg)
+            total += 1
+    return counts, badges, total
 
-    header = '# This is a Collection of all the LeetCode Problems that I have Solved!\n'
-    if header not in readme:
-        readme.insert(0, header + '\n')
 
-    if start_line is not None and end_line is not None:
-        if readme[start_line:end_line] == new_table:
-            print("No changes needed in README.md")
-            sys.exit(0)  # Exit with status 0 if no changes are needed
-        readme[start_line:end_line] = new_table
+def build_table(counts, badges, total):
+    rows = ["| Language | Solutions |", "| --- | --- |"]
+    # sort by count desc, then name asc
+    for name in sorted(counts, key=lambda n: (-counts[n], n)):
+        rows.append(f"| {badges[name]} | {counts[name]} |")
+    rows.append(f"| **Total** | **{total}** |")
+    return "\n".join(rows)
+
+
+def update_readme(table, path="README.md"):
+    header = "# This is a Collection of all the LeetCode Problems that I have Solved!\n"
+    section = f"## 🧑‍💻 Languages & Stats\n\n{START_MARK}\n{table}\n{END_MARK}\n"
+
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
     else:
-        readme.append('\n## 🧑‍💻 Languages & Stats\n')
-        readme.append('| Language      | Solutions |\n')
-        readme.append('| ------------- | ----------|\n')
-        readme.extend(new_table)
+        content = header + "\n"
 
-    with open('README.md', 'w') as file:
-        file.writelines(readme)
+    if START_MARK in content and END_MARK in content:
+        pre = content[: content.index(START_MARK)]
+        post = content[content.index(END_MARK) + len(END_MARK):]
+        new_content = f"{pre}{START_MARK}\n{table}\n{END_MARK}{post}"
+    else:
+        # No markers yet (first migration): drop any existing stats section
+        # (everything from the "Languages & Stats" heading onward) and append
+        # a fresh, marker-delimited one so future runs are idempotent.
+        stats_heading = "## 🧑‍💻 Languages & Stats"
+        if stats_heading in content:
+            content = content[: content.index(stats_heading)]
+        if not content.startswith(header):
+            content = header + "\n" + content
+        new_content = content.rstrip() + "\n\n" + section
 
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            if f.read() == new_content:
+                print("No changes needed in README.md")
+                sys.exit(0)
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(new_content)
     print("README.md updated")
 
+
 if __name__ == "__main__":
-    counts, totalCount = count_files_by_extension('.')
-    update_readme(counts, totalCount)
+    counts, badges, total = count_solutions(".")
+    update_readme(build_table(counts, badges, total))


### PR DESCRIPTION
Rewrites update_readme.py to count all solution languages (C++, Bash, JS, Go, Rust, etc.), fixes the C/C++ split (cpp files were uncounted; C showed 0), excludes non-solution files, and emits a marker-delimited, sorted, idempotent stats table. Also bumps the workflow actions (checkout@v4, setup-python@v5) and adds workflow_dispatch + explicit permissions. Regenerated README now reports 314 solutions.